### PR TITLE
Add Free Crypto Price API to Financial Data & Market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@
 - [Alpha Vantage](https://www.alphavantage.co/) – Free and paid APIs for market data.
 - [Polygon.io](https://polygon.io/) – Real-time and historical financial market data APIs.
 - [Quandl (Nasdaq Data Link)](https://data.nasdaq.com/) – Economic and financial datasets.
+- [Free Crypto Price API](https://crypto-price-landing.vercel.app) – Real-time prices for 275+ crypto assets via Hyperliquid. No API key, no rate limits, free forever.
 
 ## Fraud, Risk & Compliance
 


### PR DESCRIPTION
Adding **[Free Crypto Price API](https://crypto-price-landing.vercel.app)** to the Financial Data & Market APIs section.

- Real-time prices for 275+ crypto assets sourced from Hyperliquid on-chain data
- No API key, no rate limits, completely free
- Simple REST: `GET https://agent-gateway-kappa.vercel.app/api/services/crypto-price?symbols=BTC,ETH,SOL`
- Complements existing entries (Bloomberg, Alpha Vantage, Polygon.io) with a free DeFi/crypto-native data source