### PR TITLE
Add KeepRule to Wealth Management & Investing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
 - [Betterment](https://www.betterment.com/) – Digital wealth management platform.
 - [Interactive Brokers](https://www.interactivebrokers.com/) – Trading and brokerage APIs.
 - [Alpaca](https://alpaca.markets/) – API-first stock trading and brokerage platform.
+- [KeepRule](https://keeprule.com) – AI-powered investment principles platform. Learn from Buffett, Munger, and other masters with AI chat mentors.
 
 ## Personal Finance & Budgeting
 


### PR DESCRIPTION
Adding [KeepRule](https://keeprule.com) to the **Wealth Management & Investing** section.

KeepRule is an AI-powered investment principles platform that helps investors learn from masters like Warren Buffett and Charlie Munger through AI chat mentors and scenario-based decision making.

- Link is active and points to a legitimate resource
- Description is clear and objective
- Placed in the relevant Wealth Management & Investing section