### PR TITLE
Add Augea to Blockchain & Crypto Infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@
 - [Chainalysis](https://www.chainalysis.com/) – Blockchain analytics and compliance tools.
 - [Fireblocks](https://www.fireblocks.com/) – Secure digital asset custody and transfer platform.
 - [Alchemy](https://www.alchemy.com/) – Blockchain developer platform and APIs.
+- [Augea](https://augea.io) - Snapshot-backed crypto exchange fee comparison across countries, assets, and payment rails. Every estimate links to a reproducible snapshot with transparent provenance.
+
 
 ## Accounting, Invoicing & Tax
 


### PR DESCRIPTION
Adds Augea (https://augea.io), a methodology-first comparison tool under Blockchain & Crypto Infrastructure.

What it does:
- Compares real total cost of buying BTC and ETH across exchanges, countries, and payment rails (card, bank, SEPA)
- Every number is backed by a timestamped snapshot ID with transparent provenance
- Shows "unknown" with a reason instead of guessing when data cannot be verified
- Covers US, UK, DE, FR, SE, CA, AU, SG across 16+ exchanges

Happy to adjust the description or section placement if another fit works better.
