### PR TITLE
Add Sweepbase to Personal Finance & Budgeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Monzo](https://monzo.com/) – Digital bank with built-in budgeting tools.
 - [Revolut](https://www.revolut.com/) – Financial super app with banking, cards, and analytics.
 - [Emma](https://emma-app.com/) – Personal finance app for tracking spending and subscriptions.
+- [Sweepbase](https://sweepbase.net/) – Aggregator comparing 139 crypto debit and credit cards by real fees.
 
 ## Financial Data & Market APIs
 


### PR DESCRIPTION
## Summary

Adds [Sweepbase](https://sweepbase.net/) to the **Personal Finance & Budgeting** section.

Sweepbase is a free comparison tool for crypto-linked debit and credit cards — currently covering 139 cards across regions (USA, EU, UK, LATAM, Asia). It normalizes real-world fees (FX, ATM, staking requirements, annual) so users can compare across issuers without relying on the marketing numbers.

It fits alongside Revolut, Emma, Mint and YNAB as a consumer-facing personal finance utility, with the additional angle of covering crypto-native issuers (Crypto.com, Coinbase, Binance, Nexo, Plasma, etc.) that traditional comparison sites do not.

## Disclosure

I maintain Sweepbase. The tool is free, has no paywall or lead capture, and is intended as a neutral reference. Happy to adjust the description or relocate the entry if you'd prefer a different section.

## Checklist

- [x] Link is active and points to the official site.
- [x] Description is short and objective (follows existing pattern).
- [x] No duplicate — Sweepbase is not currently in the list.
- [x] Single entry, single link.