### PR TITLE
Add Sharpe to market data APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Alpha Vantage](https://www.alphavantage.co/) – Free and paid APIs for market data.
 - [Polygon.io](https://polygon.io/) – Real-time and historical financial market data APIs.
 - [Quandl (Nasdaq Data Link)](https://data.nasdaq.com/) – Economic and financial datasets.
+- [Sharpe](https://www.sharpe.ai/docs/free-api) – Crypto market intelligence API for derivatives positioning, funding rates, arbitrage, narratives, exchange listings, and news.
 
 ## Fraud, Risk & Compliance
 


### PR DESCRIPTION
## Thank you for your contribution!

### Checklist

- [x] My submission is useful and relevant to this list.
- [x] I've added a short description for the resource.
- [x] The link is not a duplicate.
- [x] The link is working and publicly accessible.
- [x] I've checked that the resource follows the quality and content standards.
- [x] I have not added multiple links to promote a single source.

### Description of the Change

Adds Sharpe to Financial Data & Market APIs. I placed it there rather than Blockchain & Crypto Infrastructure because the linked resource is the API documentation for market intelligence data, not exchange or node infrastructure.

Website URL: https://www.sharpe.ai/docs/free-api
Validation: `git diff --check` passes.
Linear: SHA-154

### Additional Notes

Disclosure: I work on Sharpe.