### PR TITLE
Add Finterm to Wealth Management & Investing

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Betterment](https://www.betterment.com/) – Digital wealth management platform.
 - [Interactive Brokers](https://www.interactivebrokers.com/) – Trading and brokerage APIs.
 - [Alpaca](https://alpaca.markets/) – API-first stock trading and brokerage platform.
+- [Finterm](https://finterm.xyz) – Browser-based financial terminal with stock and crypto charts, SEC filing fundamentals, and a strategy backtester.
 
 ## Personal Finance & Budgeting
 


### PR DESCRIPTION
Adds **Finterm** (https://finterm.xyz) under **Wealth Management & Investing**.

Finterm is a browser-based financial terminal with stock and crypto charts, SEC filing fundamentals, and a strategy backtester. The entry follows the existing style (en-dash separator, short objective description), the link is live, and it is not a duplicate.

Checklist:
- [x] Link is active and legitimate
- [x] Fits the scope/category of the list
- [x] Description is clear and objective
- [x] Single link, no duplicate