### PR TITLE
Add Eulerpool to Financial Data & Market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Refinitiv](https://www.refinitiv.com/) – Market data and financial infrastructure provider.
 - [Alpha Vantage](https://www.alphavantage.co/) – Free and paid APIs for market data.
 - [Polygon.io](https://polygon.io/) – Real-time and historical financial market data APIs.
+- [Eulerpool](https://eulerpool.com/financial-data-api) – Financial data API for equities, ETFs, funds, crypto, forex, bonds, and macro (FRED/ECB/IMF/World Bank) with fundamentals, estimates, ownership and screeners. Free tier; includes an MCP server for AI agents.
 - [Quandl (Nasdaq Data Link)](https://data.nasdaq.com/) – Economic and financial datasets.
 
 ## Fraud, Risk & Compliance


### PR DESCRIPTION
Adds **Eulerpool** to Financial Data & Market APIs. Disclosure: I'm affiliated with Eulerpool. It's a developer-first financial-data API (equities, ETFs, funds, crypto, forex, bonds, macro) with a free tier and a native MCP server — same category as Bloomberg/Refinitiv/Polygon already listed. https://eulerpool.com/financial-data-api