### PR TITLE
Add Superhighway insurance & InsurTech research agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Alpha Vantage](https://www.alphavantage.co/) – Free and paid APIs for market data.
 - [Polygon.io](https://polygon.io/) – Real-time and historical financial market data APIs.
 - [Quandl (Nasdaq Data Link)](https://data.nasdaq.com/) – Economic and financial datasets.
+- [Superhighway](https://superhighway.walls.sh/guides/insurtech-research-agent) – Live web search API for AI agents; guide for researching insurance markets, carriers, underwriting trends, and InsurTech. Pay-per-call USDC via x402.
 
 ## Fraud, Risk & Compliance
 


### PR DESCRIPTION
Adds [Superhighway](https://superhighway.walls.sh/guides/insurtech-research-agent) to Financial Data & Market APIs — a live web search API plus a guide for building Python agents that research insurance markets, carrier landscapes, underwriting/loss trends, and InsurTech ecosystem innovation. Pay-per-call USDC micropayments via x402 (no signup required).