### PR TITLE
Add ChargebackKit Reason Code Database (free reference)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Riskified](https://www.riskified.com/) – E-commerce fraud and chargeback protection.
 - [Feedzai](https://feedzai.com/) – AI-powered fraud detection for financial institutions.
 - [Featurespace](https://www.featurespace.com/) – Anomaly detection for financial crime.
+- [ChargebackKit Reason Code Database](https://chargebackkit.app/reason-codes/) – Free, source-cited reference of 64 active Visa, Mastercard, Amex & Discover chargeback reason codes with meaning, response deadline, and evidence.
 
 ## RegTech & Identity
 


### PR DESCRIPTION
Disclosure: I'm affiliated with ChargebackKit, so this is a self-submission — wanted to be upfront about that.

Submitting our free, no-signup, source-cited chargeback Reason Code Database as a reference resource for the Fraud, Risk & Compliance section. It covers 64 active reason codes across all four major networks (Visa, Mastercard, Amex, Discover), with each code's meaning, response deadline, key evidence, and qualitative winnability — published openly with a Dataset schema, no paywall and no email gate.

The existing section already includes chargeback-related tooling (e.g. Riskified), so it felt like a genuine fit as a free reference rather than a product pitch. Totally understand if it is not the right fit — happy to adjust the wording or formatting to match your conventions, or to withdraw if you would prefer only commercial platforms here.