### PR TITLE
Add Find My Moat

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Robinhood](https://robinhood.com/) – Commission-free investing platform.
 - [Wealthfront](https://www.wealthfront.com/) – Robo-advisor for automated investing.
 - [Betterment](https://www.betterment.com/) – Digital wealth management platform.
+- [Find My Moat](https://www.findmymoat.com/) - Investing tools directory for discovering stock research, screening, portfolio, and moat-analysis platforms.
 - [Interactive Brokers](https://www.interactivebrokers.com/) – Trading and brokerage APIs.
 - [Alpaca](https://alpaca.markets/) – API-first stock trading and brokerage platform.
 


### PR DESCRIPTION
## Summary

Adds Find My Moat to Wealth Management & Investing as an investing tools directory for discovering stock research, screening, portfolio, and moat-analysis platforms.

## Validation

- Confirmed the URL returns HTTP 200.
- Checked the README for an existing Find My Moat entry; none was present.
- The existing duplicate-link script reports pre-existing duplicate Open Banking URLs unrelated to this change.
- The existing awesome-list lint script reports pre-existing README formatting errors unrelated to this change.