### PR TITLE
Add EDGAR Events to Financial Data & Market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Polygon.io](https://polygon.io/) – Real-time and historical financial market data APIs.
 - [Eulerpool](https://eulerpool.com/financial-data-api) – Financial data API for equities, ETFs, crypto, forex, bonds, and macroeconomic datasets.
 - [Quandl (Nasdaq Data Link)](https://data.nasdaq.com/) – Economic and financial datasets.
+- [EDGAR Events](https://edgarevents.com/) – SEC filings as typed JSON: 8-K item codes with materiality flags, 13D/13G activist stakes, IPO and merger forms, and HMAC-signed webhooks.
 
 ## Fraud, Risk & Compliance
 


### PR DESCRIPTION
Adds EDGAR Events to Financial Data & Market APIs, alongside Alpha Vantage, Polygon.io, Eulerpool, and Quandl.

EDGAR Events turns SEC EDGAR filings into typed JSON: 8-K item codes with materiality flags, SC 13D/13G activist and passive stakes resolved to holder/target/percent, S-1/424B IPO forms, merger proxies (425/DEFM14A), and HMAC-signed webhooks. Free tier plus a $29/mo plan; OpenAPI at https://api.edgarevents.com/openapi.json.

Description kept short to match the section style, per CONTRIBUTING. Independent service, not affiliated with the SEC.