### PR TITLE
Add FilingFirehose to Financial Data & Market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Alpha Vantage](https://www.alphavantage.co/) – Free and paid APIs for market data.
 - [Polygon.io](https://polygon.io/) – Real-time and historical financial market data APIs.
 - [Eulerpool](https://eulerpool.com/financial-data-api) – Financial data API for equities, ETFs, crypto, forex, bonds, and macroeconomic datasets.
+- [FilingFirehose](https://filingfirehose.com/) – SEC EDGAR JSON API with body-text-classified 8-Ks (flags buried events), activist-tagged Schedule 13D/G, S-3/424B5 ATM detection. Free per-ticker forensic risk score for any US stock.
 - [Quandl (Nasdaq Data Link)](https://data.nasdaq.com/) – Economic and financial datasets.
 
 ## Fraud, Risk & Compliance


### PR DESCRIPTION
Adding FilingFirehose to Financial Data & Market APIs.

Why it fits:
- SEC EDGAR JSON API for 8-K, 10-K, 10-Q, S-3 filings with structured semantic enrichment
- Body-text-classified 8-Ks flag buried events (Item 1.05 cyber, 5.02 officer departures hidden in Item 8.01)
- Schedule 13D/G with 21+ activist filers auto-tagged
- Free per-ticker forensic risk score for any US stock
- Complementary to existing entries like Alpha Vantage and Polygon: those are market data, FilingFirehose is filing intelligence

Placed alphabetically between Eulerpool and Quandl.