### PR TITLE
Add Adanos to Financial Data & Market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 
 ## Financial Data & Market APIs
 
+- [Adanos](https://adanos.org/) – Market sentiment API for stocks and crypto using Reddit, X / FinTwit, financial news, and Polymarket signals.
 - [Bloomberg](https://www.bloomberg.com/professional/) – Financial data, analytics, and news platform.
 - [Refinitiv](https://www.refinitiv.com/) – Market data and financial infrastructure provider.
 - [Alpha Vantage](https://www.alphavantage.co/) – Free and paid APIs for market data.


### PR DESCRIPTION
## Summary
- add Adanos to Financial Data & Market APIs
- link directly to https://adanos.org/

## Fit
Adanos provides market sentiment data for stocks and crypto using Reddit, X / FinTwit, financial news, and Polymarket signals.

## Checks
- git diff --check
- python3 check_readme_links.py README.md --timeout 10 (Adanos link returns 200; existing upstream links still report failures)
- npx --yes awesome-lint README.md (reports existing upstream style issues)