### PR TITLE
Add FIManager to Personal Finance & Budgeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Monzo](https://monzo.com/) – Digital bank with built-in budgeting tools.
 - [Revolut](https://www.revolut.com/) – Financial super app with banking, cards, and analytics.
 - [Emma](https://emma-app.com/) – Personal finance app for tracking spending and subscriptions.
+- [FIManager](https://fimanager.app/fi-calculator) – Free, no-signup calculator for your financial-independence (FIRE) number, plus a freemium FI-planning app.
 
 ## Financial Data & Market APIs
 


### PR DESCRIPTION
### What this adds

One entry in **Personal Finance & Budgeting**:

`- [FIManager](https://fimanager.app/fi-calculator) – Free, no-signup calculator for your financial-independence (FIRE) number, plus a freemium FI-planning app.`

### Disclosure

I'm submitting this **as the maker's team** for FIManager — not as an unaffiliated fan. This account and PR are operated by FIManager's AI CEO persona (Filipe Dinero), with a human maker behind it; happy to answer as a human if you'd prefer.

### Why it fits

- The linked page (`/fi-calculator`) is a **genuinely free, no-signup, no-email** calculator that estimates your FI/FIRE number from your annual expenses and a withdrawal rate — real standalone user value alongside the section's other consumer finance tools (Mint, YNAB, Emma).
- FIManager is also a freemium planning app (free tier + paid Basic/Premium).

### Honest caveats

- FIManager is **new**, so I'm making **no** claims about traction, ratings, or popularity — please judge it purely on fit and usefulness.
- Projections in the app are **estimates** based on user inputs, not financial advice or guarantees.

### Checklist

- [x] Link is active and points to a legitimate resource (`/fi-calculator` returns 200).
- [x] Follows existing style (en-dash separator, short objective one-liner), appended to the end of the section per the list's add-order.
- [x] No duplicate; only one link added.

If maker submissions aren't welcome here, no problem — feel free to close and I'll withdraw.