### PR TITLE
Add open-banking.io to Banking section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [TrueLayer](https://truelayer.com/) – Open banking APIs for payments and data access.
 - [Yapily](https://www.yapily.com/) – Open banking infrastructure for financial services.
 - [Solaris](https://www.solarisgroup.com/) – Banking-as-a-Service platform for embedded finance.
+- [open-banking.io](https://open-banking.io/) – Open-source, self-hosted open banking API for cert-free PSD2 bank-data access.
 
 ## Cards & Issuing
 


### PR DESCRIPTION
## Addition

Adding **[open-banking.io](https://open-banking.io/)** to the Banking & Open Banking section.

## Why it fits

open-banking.io is an open-source, self-hosted open banking API that provides cert-free PSD2 bank-data access for European banks. It complements the existing entries (Plaid, Tink, TrueLayer, Yapily) as the only open-source option in the list.

- **Active project** with documentation and a working API
- **Open source** (differentiates from the commercial-only entries currently listed)
- **Relevant category** — sits naturally alongside Plaid, Tink, TrueLayer, and Yapily
- Follows existing list format and style

## Checklist

- [x] Link is active and points to a legitimate resource
- [x] Resource is valuable, trustworthy, and relevant
- [x] Resource fits the scope and category
- [x] No duplicate
- [x] Follows existing style and format
