### PR TITLE
Add SmartBizCalc to Accounting, Invoicing & Tax

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [FreshBooks](https://www.freshbooks.com/) – Invoicing and accounting for small businesses.
 - [Wave](https://www.waveapps.com/) – Free accounting and invoicing tools.
 - [TaxJar](https://www.taxjar.com/) – Automated sales tax calculation and filing.
+- [SmartBizCalc](https://smartbizcalc.com/) – 300+ free calculators for small business finance: payroll tax, self-employment tax, break-even, profit margins, insurance, startup costs, and more.
 
 ## Developer Tools & Infrastructure
 


### PR DESCRIPTION
SmartBizCalc (https://smartbizcalc.com/) offers 300+ free calculators covering small business finance — payroll tax, self-employment tax, break-even analysis, profit margins, insurance cost estimates, startup costs, and more. Fits naturally in the Accounting, Invoicing & Tax section alongside Wave and TaxJar.