### PR TITLE
Add OpenCard DB to Cards & Issuing

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Adyen Issuing](https://www.adyen.com/card-issuing) – End-to-end card issuing solution.
 - [Unit](https://www.unit.co/) – Embedded finance platform with card issuing and banking.
 - [Synapse](https://synapsefi.com/) – Banking and card issuing APIs for FinTechs.
+- [OpenCard DB](https://github.com/thedavidweng/opencard-db) – Open dataset of 189 credit card products across the US, Canada, and China, with structured metadata on issuer, network, fees, rewards, and benefits. JSON/CSV/YAML exports and a read-only REST API. CC BY 4.0.
 
 ## Lending & Credit
 


### PR DESCRIPTION
Adds OpenCard DB to the **Cards & Issuing** section.

OpenCard DB is a community-maintained open dataset of credit card product metadata — 189 cards across the US, Canada, and China, with structured fields for issuer, network, network tier, annual fee, FX fee, APR, rewards, signup bonus, and benefits, plus source citations per card.

- Per-card JSON validated against a JSON Schema, updated via pull requests.
- Bulk exports in JSON/CSV/YAML served from a CDN (no login, no API key, no rate limits on the CDN path).
- Read-only REST API with filtering and search.
- Data: CC BY 4.0. Code: MIT.

Fits the Cards & Issuing category as an open reference dataset on card products themselves (complementary to the existing issuing-platform entries). Description kept short and objective per the contributing guidelines; no self-promotion.