### PR TITLE
Add Banking Access Index to Financial Data & Market APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Polygon.io](https://polygon.io/) – Real-time and historical financial market data APIs.
 - [Eulerpool](https://eulerpool.com/financial-data-api) – Financial data API for equities, ETFs, crypto, forex, bonds, and macroeconomic datasets.
 - [Quandl (Nasdaq Data Link)](https://data.nasdaq.com/) – Economic and financial datasets.
+- [Banking Access Index](https://www.globalsolo.global/data/banking-access-index) – CC-BY dataset of which US business banking providers accept non-resident founders, by country.
 
 ## Fraud, Risk & Compliance
 


### PR DESCRIPTION
Adds one entry to **Financial Data & Market APIs**.

```
- [Banking Access Index](https://www.globalsolo.global/data/banking-access-index) – CC-BY dataset of which US business banking providers accept non-resident founders, by country.
```

**Disclosure up front:** I maintain this dataset. Your guidelines rule out self-promotion, so you should weigh it on that basis — I think it qualifies as a resource rather than a promotion, and here is the case, but the call is yours.

**What it is.** A structured record of which US business banking providers will open an account for a founder based on their country of residence, with a verbatim sourced quote behind each claim and an explicit `unknown` state where no published source answers the question. CC-BY 4.0, downloadable as CSV and JSON, archived with a DataCite DOI (10.5281/zenodo.21336392) and re-verified on a quarterly cadence.

**Why this section.** The section already holds data providers rather than only APIs (Bloomberg, Refinitiv, Quandl). This is the same kind of thing: a financial dataset with an open endpoint, not a product page.

**Not a duplicate.** The nearest existing entries under Banking & Open Banking cover account *connectivity* — reading transactions from accounts that already exist. Eligibility to open one in the first place, by residency, is a different question and nothing in the list currently answers it.

**Checklist:**
- [x] Link active — `/data/banking-access-index` returns 200.
- [x] Fits the section's scope and existing taxonomy.
- [x] Description short, objective, no marketing language.
- [x] Single link, appended to the end of the section (that section is not alphabetically ordered).
- [x] No duplicate.

Happy to reword the description or move it to another section if you would rather place it elsewhere — or to close this if you consider self-submitted resources out of scope.